### PR TITLE
fix perm to octal

### DIFF
--- a/latex/main.go
+++ b/latex/main.go
@@ -48,7 +48,7 @@ func MakeTable(fileName string, entries [][]Entry) {
 		}
 		output.WriteString(str + "\\\\ \\hline\n")
 	}
-	ioutil.WriteFile(fileName, output.Bytes(), 777)
+	ioutil.WriteFile(fileName, output.Bytes(), 0777)
 }
 
 func MakeTableWithLookup(fileName string, tbl Table) {
@@ -64,7 +64,7 @@ func MakeTableWithLookup(fileName string, tbl Table) {
 		}
 		output.WriteString(str + "\\\\ \\hline\n")
 	}
-	ioutil.WriteFile(fileName, output.Bytes(), 777)
+	ioutil.WriteFile(fileName, output.Bytes(), 0777)
 }
 
 func MakeColoredPointGraph(fileName string, labelToMark map[string]string, points []Point) {
@@ -78,7 +78,7 @@ func MakeColoredPointGraph(fileName string, labelToMark map[string]string, point
 		}
 		output.WriteString("};\n")
 	}
-	ioutil.WriteFile(fileName, output.Bytes(), 777)
+	ioutil.WriteFile(fileName, output.Bytes(), 0777)
 }
 
 func MakeLineGraph(fileName string, points []Point) {
@@ -87,7 +87,7 @@ func MakeLineGraph(fileName string, points []Point) {
 		output.WriteString(p.ToString() + "\n")
 	}
 	output.WriteString("};")
-	ioutil.WriteFile(fileName, output.Bytes(), 777)
+	ioutil.WriteFile(fileName, output.Bytes(), 0777)
 }
 
 func SelectPoints(pts []Point, label string) []Point {

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func MakeTable(fileName string, entries [][]Entry) {
 		}
 		output.WriteString(str + "\\\\ \\hline\n")
 	}
-	ioutil.WriteFile(fileName, output.Bytes(), 777)
+	ioutil.WriteFile(fileName, output.Bytes(), 0777)
 }
 
 func MakeTableWithLookup(fileName string, tbl Table) {
@@ -63,7 +63,7 @@ func MakeTableWithLookup(fileName string, tbl Table) {
 		}
 		output.WriteString(str + "\\\\ \\hline\n")
 	}
-	ioutil.WriteFile(fileName, output.Bytes(), 777)
+	ioutil.WriteFile(fileName, output.Bytes(), 0777)
 }
 
 func MakeColoredPointGraph(fileName string, labelToMark map[string]string, points []Point) {
@@ -77,7 +77,7 @@ func MakeColoredPointGraph(fileName string, labelToMark map[string]string, point
 		}
 		output.WriteString("};\n")
 	}
-	ioutil.WriteFile(fileName, output.Bytes(), 777)
+	ioutil.WriteFile(fileName, output.Bytes(), 0777)
 }
 
 func MakeLineGraph(fileName string, points []Point) {
@@ -86,7 +86,7 @@ func MakeLineGraph(fileName string, points []Point) {
 		output.WriteString(p.ToString() + "\n")
 	}
 	output.WriteString("};")
-	ioutil.WriteFile(fileName, output.Bytes(), 777)
+	ioutil.WriteFile(fileName, output.Bytes(), 0777)
 }
 
 func SelectPoints(pts []Point, label string) []Point {


### PR DESCRIPTION
Hi.
I found out that you pass a perm for WriteFile method as decimal.
But you want to pass octal arn't you?

For example, 
`0777` is `111111111` in binary and it means `rwxrwxrwx`.
`777` is `1100001001` in binary and it means `r----x--x`.

If you want to set perm `r----x--x`, you should use `0411` instead of decimal `777`.  